### PR TITLE
Updated Boolean Serialiser to use writeInt()/readInt() for cleanliness

### DIFF
--- a/src/cn/nekocode/plugin/parcelablegenerator/typeserializers/BooleanSerializer.java
+++ b/src/cn/nekocode/plugin/parcelablegenerator/typeserializers/BooleanSerializer.java
@@ -27,10 +27,10 @@ public class BooleanSerializer extends TypeSerializer {
     }
 
     public String readValue() {
-        return "1.toByte().equals(source.readByte())";
+        return "1.equals(source.readInt())";
     }
 
     public String writeValue() {
-        return "dest?.writeByte((if(" + field.getName() + ") 1 else 0).toByte())";
+        return "dest?.writeInt((if(" + field.getName() + ") 1 else 0))";
     }
 }


### PR DESCRIPTION
The parcelable 'writeByte()' and 'readByte()' methods use the integer versions internally. The change makes the resulting code cleaner and has the side benefit of using fewer casts.
